### PR TITLE
Fix players being teleported under the bedrock when travelling to the Nether.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
     }
     maven {
         name = "Hwyla Maven"
-        url  "http://tehnut.info/maven"
+        url  "http://maven.tehnut.info"
     }
     maven {
         name = "TOP Maven"

--- a/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
+++ b/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
@@ -149,7 +149,7 @@ public class TeleporterHandler {
                 spawnPosition.setPos(pos.getX(), possibleYPosition, pos.getZ());
             }
         }
-        while(spawnPosition.getY() != -1);
+        while(spawnPosition.getY() == -1);
 
         return spawnPosition;
     }

--- a/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
+++ b/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java
@@ -1,7 +1,6 @@
 package jackyy.dimensionaledibles.util;
 
 import jackyy.dimensionaledibles.DimensionalEdibles;
-import net.minecraft.block.BlockLiquid;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;


### PR DESCRIPTION
Closes #25. 

During the development and having players play through our pack, we have gotten several reports of the behavior that was reported in #25. Having looked into the code, it can be seen that for this method here: https://github.com/JackyyTV/DimensionalEdibles/blob/dev-1.12.2/src/main/java/jackyy/dimensionaledibles/util/TeleporterHandler.java#L137
the spawn position calculation will fail when both while loops fail to find a valid position. This will happen when there is no spawnable location found in the passed in Y column, and after both while loops fail, the Y position will be returned with a value of 0, causing players to spawn below/in bedrock.

This PR refactors the search for a spawnable location, such that if no spawnable location is found in the Y range for a given `x, z` coordinate pair, then the x or z coordinate will be incremented, and the Y column will be scanned again for a suitable spawning location. This will continue until a suitable spawning location is found.

Let me know if there are any issues present, or if there is anything I should change.